### PR TITLE
Begin pulling runtime configuration out & using hashed passwords

### DIFF
--- a/config/LocalhostDevConfig.go
+++ b/config/LocalhostDevConfig.go
@@ -10,7 +10,7 @@ func (l *LocalhostDevConfig) PasswordSalt() []byte {
 }
 
 func (l *LocalhostDevConfig) AccessJWTTTL() int {
-	return 10 * 60 * 60 // 600 minutes
+	return 10 * 60 // 10 minutes
 }
 
 func (l *LocalhostDevConfig) AccessJWTSigningKey() []byte {

--- a/config/LocalhostDevConfig.go
+++ b/config/LocalhostDevConfig.go
@@ -1,0 +1,30 @@
+package config
+
+// BechamelRuntimeConfig configuration implementation for local development
+// with this running on localhost and not using any external resources
+type LocalhostDevConfig struct {
+}
+
+func (l *LocalhostDevConfig) PasswordSalt() []byte {
+	return []byte("Don't be salty!")
+}
+
+func (l *LocalhostDevConfig) AccessJWTTTL() int {
+	return 10 * 60 * 60 // 600 minutes
+}
+
+func (l *LocalhostDevConfig) AccessJWTSigningKey() []byte {
+	return []byte("GetThisFromENV")
+}
+
+func (l *LocalhostDevConfig) RefreshJWTTTL() int {
+	return 7 * 24 * 60 * 60 // 7 days
+}
+
+func (l *LocalhostDevConfig) RefreshJWTSigningKey() []byte {
+	return []byte("GetThisFromENV")
+}
+
+func NewLocalhostDevConfig() *LocalhostDevConfig {
+	return &LocalhostDevConfig{}
+}

--- a/config/config_base.go
+++ b/config/config_base.go
@@ -1,0 +1,20 @@
+package config
+
+// This interface represents configuration parameters for the Bechamel API.
+// In a deployed setting, an implementation will typically get values
+// from either a secure source like Microsoft Azure Key Vault,
+// or from the deployment environment for less security sensitive values
+
+type BechamelRuntimeConfig interface {
+	PasswordSalt() []byte
+
+	// Number of seconds generated JWT tokens are valid for before expiration
+	// when generating with the method not requiring an expiration period.
+	AccessJWTTTL() int
+	RefreshJWTTTL() int
+
+	AccessJWTSigningKey() []byte
+	RefreshJWTSigningKey() []byte
+}
+
+var RuntimeConfig BechamelRuntimeConfig

--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 )
 
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-)
+require github.com/google/go-cmp v0.5.8 // indirect
 
 require github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 
@@ -41,7 +37,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/crypto v0.9.0 // indirect
+	golang.org/x/crypto v0.9.0
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/internal/jwt_utils_test.go
+++ b/internal/jwt_utils_test.go
@@ -5,7 +5,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"project-ricotta/bechamel-api/config"
 )
+
+func init() {
+	config.RuntimeConfig = config.NewLocalhostDevConfig()
+}
 
 func TestValidateErrorForEmptyAccessJWT(t *testing.T) {
 	expected := "JWT token to verify must be non-empty"

--- a/internal/password_utils.go
+++ b/internal/password_utils.go
@@ -1,0 +1,19 @@
+package internal
+
+import (
+	"encoding/base64"
+	"log"
+
+	"golang.org/x/crypto/scrypt"
+
+	"project-ricotta/bechamel-api/config"
+)
+
+func HashPassword(password string) string {
+	salt := config.RuntimeConfig.PasswordSalt()
+	outKey, err := scrypt.Key([]byte(password), salt, 32768, 8, 1, 32)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(outKey)
+}

--- a/internal/user_access.go
+++ b/internal/user_access.go
@@ -13,8 +13,10 @@ import (
 )
 
 var lasagnaLoveUsers = []model.LasagnaLoveUser{
-	{ID: 1, Username: "TestUser1", Password: "password1", GivenName: "Test", FamilyName: "UserOne"},
-	{ID: 2, Username: "TestUser2", Password: "password2", GivenName: "Test", FamilyName: "UserTwo"},
+	{ID: 1, Username: "TestUser1", Password: "EsX3b/B4fCYGb2+iAs4fAIXQtiq3EydUDi03ECVvTEE=", // "password1"
+		GivenName: "Test", FamilyName: "UserOne"},
+	{ID: 2, Username: "TestUser2", Password: "TnhbYUymFq5gr1jvyw1AmTviqlp3sYp7t0VxfT7ut1M=", // "password2"
+		GivenName: "Test", FamilyName: "UserTwo"},
 }
 
 func findUser(userFilter func(model.LasagnaLoveUser) bool) (model.LasagnaLoveUser, error) {
@@ -32,7 +34,7 @@ func AuthorizeUser(userName string, password string) (model.LasagnaLoveUser, err
 	}
 
 	return findUser(func(u model.LasagnaLoveUser) bool {
-		return u.Username == userName && u.Password == password
+		return u.Username == userName && u.Password == HashPassword(password)
 	})
 }
 
@@ -63,6 +65,7 @@ func AddNewUser(newUserProfile model.LasagnaLoveUser) (model.LasagnaLoveUser, er
 	}
 
 	newUserProfile.ID = len(lasagnaLoveUsers) + 1
+	newUserProfile.Password = HashPassword(newUserProfile.Password)
 	lasagnaLoveUsers = append(lasagnaLoveUsers, newUserProfile)
 	return newUserProfile, nil
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"project-ricotta/bechamel-api/config"
+
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
 func main() {
+	config.RuntimeConfig = config.NewLocalhostDevConfig()
+
 	router := gin.Default()
 	var corsConfig = cors.DefaultConfig()
 	// TODO: for the time being, we allow requests from all origins.

--- a/model/LasagnaLoveUser.go
+++ b/model/LasagnaLoveUser.go
@@ -1,10 +1,28 @@
 package model
 
+import "encoding/json"
+
 type LasagnaLoveUser struct {
 	ID                 int    `json:"id"`
 	Username           string `json:"username"`
-	Password           string `json:"-"`
+	Password           string `json:"password"`
 	GivenName          string `json:"given_name"`
 	MiddleOrMaidenName string `json:"middle_or_maiden_name"`
 	FamilyName         string `json:"family_name"`
+}
+
+// This overrides the default marshaling of the structure to JSON, removing the password field value.
+// It has the unfortunate side effect of leaving an empty string entry in the generated JSON
+// which leaks out to users, but does allow the use of the same struct for GETting and POSTing user profiles.
+//
+// Simply using a marshalling entry of "-" in the struct above causes the marshalling in the POST calls
+// to create user Profiles to not unmarshall the supplied password field.
+//
+// TODO: Better ideas to accomplish allowing and reading the "password" JSON field value when creating
+// LasagnaLoveUser data structures, while not emitting these when marshalling, are welcomed.
+func (l LasagnaLoveUser) MarshalJSON() ([]byte, error) {
+	type lasagnaLoveUser LasagnaLoveUser // prevent recursion
+	x := lasagnaLoveUser(l)
+	x.Password = ""
+	return json.Marshal(x)
 }


### PR DESCRIPTION
This PR does some initial work to generalize the runtime configuration for the Bechamel API,
adding a simple configuration interface and Localhost-based implementation that is used internally.
This adds a password hashing salt to the configuration, and moves to using scrypt with this salt
to hash passwords and store only hashed passwords instead of plaintext.

This PR also restores previous Profile 'password' field marshalling behavior, to fix Profile creation.