### PR TITLE
Initial work to Dockerize API server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug locally",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "."
+        },
+        {
+            "name": "Local Docker App Debug",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "port": 4000,
+            "host": "127.0.0.1"
+        }
+    ]
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,8 +8,13 @@
   - [Verification of Go installation](#verification-of-go-installation)
 - [Developing the Bechamel API](#developing-the-bechamel-api)
   - [API documentation](#api-documentation)
-  - [Building the project](#building-the-project)
-  - [Running the server locally](#running-the-server-locally)
+  - [Developing locally](#developing-locally)
+    - [Building the project locally](#building-the-project-locally)
+    - [Running the server locally](#running-the-server-locally)
+  - [Developing locally with Docker](#developing-locally-with-docker)
+    - [Building and running the Docker container](#building-and-running-the-docker-container)
+    - [Debugging the app in the Docker container](#debugging-the-app-in-the-docker-container)
+    - [Viewing container logs](#viewing-container-logs)
   - [Running unit tests](#running-unit-tests)
   - [Writing test functions](#writing-unit-tests)
   - [Running the GitHub super-linter](#running-the-linter)
@@ -51,7 +56,13 @@ go version
 The Bechamel API documentation can be found in OpenAPI format in the documentation folder in the bechamel-api.yaml file.
 You can view this in an OpenAPI - aware file viewer such as Visual Studio Code to browse the Bechamel API.
 
-### Building the project
+### Developing locally
+
+While we encourage developers to use Docker for local development and testing, we understand that for many
+developing locally, outside a local Docker environment, may be more familiar or preferrable.
+To that end we support development locally.
+
+#### Building the project locally
 
 To verify there are no syntax or compilation issues, you may build the project. From the bechamel-api directory:
 
@@ -60,7 +71,7 @@ go mod download # download dependencies
 go build .
 ```
 
-### Running the server locally
+#### Running the server locally
 
 From a command window in the top-level bechamel-api project directory:
 
@@ -77,6 +88,45 @@ The Bechamel API server listens on `http://localhost:8080` by default. You shoul
 You can use HTTP development tools such as curl or Postman to interact with the Bechamel API server.
 
 You may stop the server with `Ctrl+C`.
+
+### Developing locally with Docker
+
+First, make sure `docker` is installed.
+
+For Windows users:
+You can install Docker Desktop from [Docker](https://docs.docker.com/desktop/install/windows-install/).
+When running on Windows, you'll need to ensure the Windows Subsystem for Linux (WSL) is installed and updated to WSL version 2. To do this:
+1. Open a Powershell windows as administrator
+2. Install WSL and a Linux distribution. To install Ubuntu 22.04:
+    `wsl --install -d Ubuntu-22.04`
+3. To make sure WSL is updated to WSL 2:
+    `wsl --update`
+4. Then make sure Docker Desktop sees the installed WSL and Linux distribution.
+In Docker Desktop's Settings | Resources | WSL integration, make sure the Ubuntu 22.04 distribution is enabled.
+You may need to hit Refresh and wait a minute or two for it to show. Once enabled, hit Apply & Restart to restart the Docker engine.
+
+#### Building and running the Docker container
+
+To run the local-based Docker container for debugging:
+1. `docker compose --file docker-compose-localdev.yml up --build --wait --detach` at the root of the repository.
+2. Make a request to the app (`curl`, or in Postman or your favorite tool) at `localhost:8080`.
+3. `docker compose --file docker-compose-localdev.yml down` to stop the container.
+
+To run the Azure dev deployment, use the docker-compose-azuredev.yml file instead.
+
+#### Debugging the app in the Docker container
+
+You can use Visual Studio Code or other tools to debug when developing locally with the Docker container.
+The Docker container composition in docker-compose-localdev.yml is set up to enable this for VS Code.
+Once the Docker container is running as per above, you can use the "Local Docker App Debug" configuration in
+the `Run and Debug` tab to connect to the debugger.
+
+[For JetBrains usage ; untested](https://www.jetbrains.com/help/go/attach-to-running-go-processes-with-debugger.html#step-1-create-a-dockerfile-configuration)
+
+#### Viewing container logs
+
+1. Start the app (see above).
+2. Run `docker compose --file docker-compose-localdev.yml logs` at the root of the repository. (Add `-f` at the end to stream the logs)
 
 ### Running unit tests
 
@@ -265,9 +315,10 @@ In this example, the reviewer is reviewing pull request #18 that is stored in a 
     git checkout pr-branch
     ```
 
-4. Install dependencies: see [Building the project](#building-the-project) above
+4. Install dependencies: see [Building the project locally](#building-the-project-locally) above
 
-5. Compile the project and ensure it executes: see [Building the project](#building-the-project) and [Running the server locally](#running-the-server-locally) above
+5. Compile the project and ensure it executes: see [Building the project locally](#building-the-project-locally)
+and [Running the server locally](#running-the-server-locally) above
 
 6. Verify the unit tests are functioning: see [Running unit tests](#running-unit-tests) above
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+# Based on instructions at https://docs.docker.com/language/golang/build-images/
+
+FROM golang:1.20 as base
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+# TODO: it's laborious to add directories to copy manually,
+# but maintaining a .dockerignore file and hoping people update it
+# may be a worse idea - may introduce security issues if it's not maintained
+# So for the time being we'll explicitly state what to copy
+COPY *.go ./
+COPY config ./config/
+COPY documentation ./documentation/
+COPY internal ./internal/
+COPY model ./model/
+
+##########
+# Configuration for developer local Docker deployment
+# Contains suggestions from https://dev.to/bruc3mackenzi3/debugging-go-inside-docker-using-vscode-4f67
+# to enable debugging locally with VS Code via Delve
+FROM base as dev
+RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
+# Build the API server with gcflags that disable inlining and optimizations
+RUN CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -o /bechamel-api-localdev-server .
+# Start the Delve server on port 4000
+CMD [ "/go/bin/dlv", "--listen=:4000", "--headless=true", "--log=true", "--accept-multiclient", "--api-version=2", "exec", "/bechamel-api-localdev-server" ]
+# CMD ["/bechamel-api-localdev-server"]
+
+
+##########
+# Configuration for Azure-deployed dev instance
+# TODO: For production deployment, build a slimmed-down Docker image
+# without development tools as described in above link in "Multi-stage builds"?
+FROM base as dev-azuredeploy
+# Build the API server with gcflags that disable inlining and optimizations
+RUN CGO_ENABLED=0 GOOS=linux go build -o /bechamel-api-server .
+# And start the server running
+CMD ["/bechamel-api-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/g
 RUN CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -o /bechamel-api-localdev-server .
 # Start the Delve server on port 4000
 CMD [ "/go/bin/dlv", "--listen=:4000", "--headless=true", "--log=true", "--accept-multiclient", "--api-version=2", "exec", "/bechamel-api-localdev-server" ]
-# CMD ["/bechamel-api-localdev-server"]
-
 
 ##########
 # Configuration for Azure-deployed dev instance

--- a/docker-compose-azuredev.yml
+++ b/docker-compose-azuredev.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  backend:
+    build:
+      image: bechamel-api-server:azuredev
+      context: .
+      target: dev-azuredeploy
+    ports:
+      - '8080:8080'

--- a/docker-compose-azuredev.yml
+++ b/docker-compose-azuredev.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   backend:
     build:
-      image: bechamel-api-server:azuredev
+      image: bechamel-api-backend-azuredev:latest
       context: .
       target: dev-azuredeploy
     ports:

--- a/docker-compose-localdev.yml
+++ b/docker-compose-localdev.yml
@@ -1,0 +1,39 @@
+version: '3'
+
+# This Docker compose file and the Dockerfile entries for the dev configuration
+# are based on information from https://dev.to/bruc3mackenzi3/debugging-go-inside-docker-using-vscode-4f67
+
+# DO NOT USE THIS CONFIGURATION for anything other than local Docker-based development
+services:
+  backend:
+    build:
+      context: .
+      target: dev
+      tags:
+        - bechamel-api-backend-localdev:latest
+    ports:
+      - '4000:4000'
+      - '8080:8080'
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - label:disable
+    # File watching https://docs.docker.com/compose/file-watch/
+    # Note: not yet functioning
+    x-develop:
+      watch:
+        - path: .
+          target: /app
+          action: rebuild
+        - path: ./config
+          target: /app/config
+          action: rebuild
+        - path: ./documentation
+          target: /app/documentation
+          action: sync
+        - path: ./internal
+          target: /app/internal
+          action: rebuild
+        - path: ./model
+          target: /app/model
+          action: rebuild

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 	router.GET("/request/:requestID", getRequestByID)
 	router.POST("/request", postRequest)
 
-	if err := router.Run("localhost:8080"); err != nil {
+	if err := router.Run("0.0.0.0:8080"); err != nil {
 		log.Fatal(fmt.Errorf("could not start Gin server: %w", err))
 	}
 }


### PR DESCRIPTION
For [PRJRICOTTA-51](https://lasagnalove.atlassian.net/browse/PRJRICOTTA-51):

Makes initial Dockerfile with two configurations:
* A "local Docker" configuration that builds a Docker image and supports a container that is intended to be debugged and developed on a developer's local (personal) environment
* The start of an "Azure development" Docker configuration for CI/CD deployment -> this is to support later work

Updates development instructions for building and running the local development Docker container.

Brings some work from project-ricotta in support of local hot-reloading, but does not complete work to support this.