### PR TITLE
Split Docker local configuration into debugger and non-debugger running

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,8 +12,6 @@
     - [Building the project locally](#building-the-project-locally)
     - [Running the server locally](#running-the-server-locally)
   - [Developing locally with Docker](#developing-locally-with-docker)
-    - [Building and running the Docker container](#building-and-running-the-docker-container)
-    - [Debugging the app in the Docker container](#debugging-the-app-in-the-docker-container)
     - [Viewing container logs](#viewing-container-logs)
   - [Running unit tests](#running-unit-tests)
   - [Writing test functions](#writing-unit-tests)
@@ -91,9 +89,7 @@ You may stop the server with `Ctrl+C`.
 
 ### Developing locally with Docker
 
-First, make sure `docker` is installed.
-
-For Windows users:
+First, make sure `docker` is installed. For Windows users:
 You can install Docker Desktop from [Docker](https://docs.docker.com/desktop/install/windows-install/).
 When running on Windows, you'll need to ensure the Windows Subsystem for Linux (WSL) is installed and updated to WSL version 2. To do this:
 1. Open a Powershell windows as administrator
@@ -105,23 +101,30 @@ When running on Windows, you'll need to ensure the Windows Subsystem for Linux (
 In Docker Desktop's Settings | Resources | WSL integration, make sure the Ubuntu 22.04 distribution is enabled.
 You may need to hit Refresh and wait a minute or two for it to show. Once enabled, hit Apply & Restart to restart the Docker engine.
 
-#### Building and running the Docker container
+The Docker configuration for debugging the Bechamel API server with a debugger
+is different from that for running the Bechamel API server without a debugger.
 
-To run the local-based Docker container for debugging:
-1. `docker compose --file docker-compose-localdev.yml up --build --wait --detach` at the root of the repository.
-2. Make a request to the app (`curl`, or in Postman or your favorite tool) at `localhost:8080`.
-3. `docker compose --file docker-compose-localdev.yml down` to stop the container.
+To debug the local-based Docker container:
+1. `docker compose --file docker-compose-dev-local-debug.yml up --build --wait --detach` at the root of the repository.
+2. Attach a debugger such as Visual Studio Code. **You must instantiate a debugging section in order for the program to run.**
+3. Make a request to the app (`curl`, or in Postman or your favorite tool) at `localhost:8080`.
+4. When finished, run `docker compose --file docker-compose-dev-local-debug.yml down` to stop the container.
 
-To run the Azure dev deployment, use the docker-compose-azuredev.yml file instead.
-
-#### Debugging the app in the Docker container
-
-You can use Visual Studio Code or other tools to debug when developing locally with the Docker container.
-The Docker container composition in docker-compose-localdev.yml is set up to enable this for VS Code.
 Once the Docker container is running as per above, you can use the "Local Docker App Debug" configuration in
 the `Run and Debug` tab to connect to the debugger.
 
 [For JetBrains usage ; untested](https://www.jetbrains.com/help/go/attach-to-running-go-processes-with-debugger.html#step-1-create-a-dockerfile-configuration)
+
+
+To run the local-based Docker container without debugging:
+1. `docker compose --file docker-compose-dev-local-run.yml up --build --wait --detach` at the root of the repository.
+2. Make a request to the app (`curl`, or in Postman or your favorite tool) at `localhost:8080`.
+3. When finished, run `docker compose --file docker-compose-dev-local-run.yml down` to stop the container.
+
+**Note** the different YAML filenames used to compose the Docker containers above.
+
+
+**Untested, incomplete** To run the Azure dev deployment, use the docker-compose-dev-azure-deploy.yml file instead.
 
 #### Viewing container logs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,21 +18,36 @@ COPY internal ./internal/
 COPY model ./model/
 
 ##########
-# Configuration for developer local Docker deployment
+# Configuration for developer local Docker-based debugging
 # Contains suggestions from https://dev.to/bruc3mackenzi3/debugging-go-inside-docker-using-vscode-4f67
 # to enable debugging locally with VS Code via Delve
-FROM base as dev
+# NOTE: this configuration REQUIRES using a Delve-compatible debugger.
+# If you want to run in your local environment without a debugger,
+# use the next configuration below
+FROM base as dev-docker-local-debug
 RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
 # Build the API server with gcflags that disable inlining and optimizations
 RUN CGO_ENABLED=0 GOOS=linux go build -gcflags "all=-N -l" -o /bechamel-api-localdev-server .
 # Start the Delve server on port 4000
-CMD [ "/go/bin/dlv", "--listen=:4000", "--headless=true", "--log=true", "--accept-multiclient", "--api-version=2", "exec", "/bechamel-api-localdev-server" ]
+# The Delve server pauses the program before execution until a debugger connection is established.
+CMD [ "/go/bin/dlv", "--listen=:4000", "--headless=true", "--log=true", "--accept-multiclient", "--api-version=2", \
+      "exec", "/bechamel-api-localdev-server" ]
+
+##########
+# Configuration for developer local Docker-based instance.
+# NOTE: this configuration is not debugger compatible.
+# Use the above configuration if you're debugging.
+FROM base as dev-docker-local-run
+# Build the API server with gcflags that disable inlining and optimizations
+RUN CGO_ENABLED=0 GOOS=linux go build -o /bechamel-api-local-server .
+# And start the server running
+CMD ["/bechamel-api-local-server"]
 
 ##########
 # Configuration for Azure-deployed dev instance
 # TODO: For production deployment, build a slimmed-down Docker image
 # without development tools as described in above link in "Multi-stage builds"?
-FROM base as dev-azuredeploy
+FROM base as dev-azure-deploy
 # Build the API server with gcflags that disable inlining and optimizations
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bechamel-api-server .
 # And start the server running

--- a/docker-compose-dev-azure-deploy.yml
+++ b/docker-compose-dev-azure-deploy.yml
@@ -3,8 +3,8 @@ version: '3'
 services:
   backend:
     build:
-      image: bechamel-api-backend-azuredev:latest
+      image: bechamel-api-dev-azure-deploy:latest
       context: .
-      target: dev-azuredeploy
+      target: dev-azure-deploy
     ports:
       - '8080:8080'

--- a/docker-compose-dev-local-debug.yml
+++ b/docker-compose-dev-local-debug.yml
@@ -8,9 +8,9 @@ services:
   backend:
     build:
       context: .
-      target: dev
+      target: dev-docker-local-debug
       tags:
-        - bechamel-api-backend-localdev:latest
+        - bechamel-api-dev-docker-local-debug:latest
     ports:
       - '4000:4000'
       - '8080:8080'

--- a/docker-compose-dev-local-run.yml
+++ b/docker-compose-dev-local-run.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+# This Docker compose file and the Dockerfile entries for the dev configuration
+# are based on information from https://dev.to/bruc3mackenzi3/debugging-go-inside-docker-using-vscode-4f67
+
+# DO NOT USE THIS CONFIGURATION for anything other than local Docker-based development
+services:
+  backend:
+    build:
+      context: .
+      target: dev-docker-local-run
+      tags:
+        - bechamel-api-dev-docker-local-run:latest
+    ports:
+      - '8080:8080'
+    # File watching https://docs.docker.com/compose/file-watch/
+    # Note: not yet functioning
+    x-develop:
+      watch:
+        - path: .
+          target: /app
+          action: rebuild
+        - path: ./config
+          target: /app/config
+          action: rebuild
+        - path: ./documentation
+          target: /app/documentation
+          action: sync
+        - path: ./internal
+          target: /app/internal
+          action: rebuild
+        - path: ./model
+          target: /app/model
+          action: rebuild


### PR DESCRIPTION
The Delve debugger for Golang halts program execution on startup, meaning the previous configuration required a debugger to attach in order for the server to run. Execution outside of a debugger was not functioning.
Giving Delve the --continue=true flag at instantiation stops this but then does not allow VS Code or debuggers to attach.

To address this, this PR splits the Docker configurations into two:
* One for running locally in/via a debugger (e.g. VS Code, JetBrains, etc.)
* A second for running locally outside of a debugger

This also renames Docker compose files and targets for clarity and includes other minor touchups.