### PR TITLE
Bechamel Profile API updates and PATCH methods

### DIFF
--- a/api_profile.go
+++ b/api_profile.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iancoleman/strcase"
 )
 
 // TODO: return something more useful for error messages
@@ -48,29 +47,41 @@ func getUserProfileByID(c *gin.Context) {
 	c.JSON(http.StatusOK, userProfile)
 }
 
+func patchUserProfile(c *gin.Context, userProfile model.LasagnaLoveUser) {
+	// NOTE: This will get the JSON as a general struct so we can pass it along
+	// Using the filled update struct type doesn't work because it defaults unfilled values,
+	// so we can't tell the difference between ones that are being set to default/blank
+	// values and those that weren't provided by the caller
+	var generalStruct model.PatchUpdateStruct
+	if err := c.BindJSON(&generalStruct); err != nil {
+		if err.Error() == "EOF" {
+			c.JSON(http.StatusBadRequest, gin.H{"errors": []string{"Missing or unparsable JSON body"}})
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"errors": []string{"Error parsing supplied message body"}})
+		}
+		return
+	}
+
+	var pascalEncasedUpdates model.PatchUpdateStruct = generalStruct.PascalCase()
+	if _, err := internal.UpdateUser(userProfile, pascalEncasedUpdates); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"errors": []string{err.Error()}})
+		return
+	}
+	// TODO: curently the API documentation specifies a successful PATCH returns
+	// an HTTP 204 NO CONTENT. We do have the updated Profile returned if we want
+	// to return it. Should we offer that option? Or let the caller
+	// re-GET the Profile if they want it?
+	c.Status(http.StatusNoContent)
+}
+
 func patchCurrentUserProfile(c *gin.Context) {
 	authHeader := c.GetHeader("Authorization")
-	_, err := internal.GetUserFromAuthHeader(authHeader)
+	userProfile, err := internal.GetUserFromAuthHeader(authHeader)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"errors": []string{"Invalid access token provided"}})
 		return
 	}
-}
-
-type patchUpdateStruct map[string]interface{}
-
-func (inStruct patchUpdateStruct) pascalCase() patchUpdateStruct {
-	retStruct := make(patchUpdateStruct)
-	for k, v := range inStruct {
-		// TODO: iterate here
-		switch vt := v.(type) {
-		case map[string]interface{}:
-			retStruct[strcase.ToCamel(k)] = (patchUpdateStruct)(vt).pascalCase()
-		default:
-			retStruct[strcase.ToCamel(k)] = vt
-		}
-	}
-	return retStruct
+	patchUserProfile(c, userProfile)
 }
 
 func patchUserProfileByID(c *gin.Context) {
@@ -87,45 +98,20 @@ func patchUserProfileByID(c *gin.Context) {
 		return
 	}
 
-	_, err = internal.GetUserByID(userID)
+	userProfile, err := internal.GetUserByID(userID)
 	if err != nil {
 		c.JSON(http.StatusBadRequest,
 			gin.H{"errors": []string{"Could not retrieve user profile for specified user id"}})
 		return
 	}
 
-	// NOTE: This will get the JSON as a general struct so we can pass it along
-	// Using the filled update struct type doesn't work because it defaults unfilled values,
-	// so we can't tell the difference between ones that are being set to default/blank
-	// values and those that weren't provided by the caller
-	var generalStruct patchUpdateStruct
-	if err = c.BindJSON(&generalStruct); err != nil {
-		if err.Error() == "EOF" {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": []string{"Missing or unparsable JSON body"}})
-		} else {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": []string{"Error parsing supplied message body"}})
-		}
-		return
-	}
-
-	var pascalEncasedUpdates patchUpdateStruct = generalStruct.pascalCase()
-	_, err = internal.UpdateUser(userID, pascalEncasedUpdates)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": []string{err.Error()}})
-		return
-	}
-	// TODO: curently the API documentation specifies a successful PATCH returns
-	// an HTTP 204 NO CONTENT. We do have the updated Profile returned if we want
-	// to return it. Should we offer that option? Or let the caller
-	// re-GET the Profile if they want it?
-	c.Status(http.StatusNoContent)
+	patchUserProfile(c, userProfile)
 }
 
 // TODO: should an API key or similar be required to POST a request to create a new user?
 // Possibly API key or a JWT token with a role with suitable permissions?
 // For demonstration and debugging purposes, any authenticated user can make new user profiles
 // at the present time. This is most certainly not what we want to deploy.
-
 func postUserProfile(c *gin.Context) {
 	var newUserProfile model.LasagnaLoveUser
 

--- a/documentation/bechamel-api.yaml
+++ b/documentation/bechamel-api.yaml
@@ -876,6 +876,11 @@ paths:
           providing the updated volunteer_info.attestations.volunteer_completed_safety_training field and value only.
 
         Do **NOT** specify null or empty values unless intending to remove the value for a field.
+
+        **If you change the user's email address with this method, the user's access and refresh tokens
+          will no longer be valid. The /login API will need to be called with the new email address
+          to generate new access and refresh tokens.**
+
         **id, creation_time and last_update_time values cannot be changed.
           A request specifying one of these fields will be rejected.**
       tags:
@@ -980,8 +985,13 @@ paths:
         Updates the profile for the user specified by the provided JWT token, changing all mutable non-password values
         to the values provided. Returns the updated user profile.
 
+        **If you change the user's email address with this method, the user's access and refresh tokens
+          will no longer be valid. The /login API will need to be called with the new email address
+          to generate new access and refresh tokens.**
+
         **Passwords cannot be changed with this method and will be ignored if specified.
         The PATCH method must be used to change passwords.**
+
         **id and creation_time and last_update_time values cannot be changed and will be ignored if speficied.**
       tags:
         - User (requester, volunteer and administrator) profiles
@@ -1048,6 +1058,11 @@ paths:
           provide the updated volunteer_info.attestations.volunteer_completed_safety_training value key and value only.
 
         Do **NOT** specify null or empty values unless intending to remove the value for a field.
+
+        **If you change the user's email address with this method, the user's access and refresh tokens
+          will no longer be valid. The /login API will need to be called with the new email address
+          to generate new access and refresh tokens.**
+
         **id, creation_time and last_update_time values cannot be changed.
           A request specifying one of these fields will be rejected.**
       tags:
@@ -1100,8 +1115,13 @@ paths:
         Updates the profile for the user specified by the provided id, changing all mutable non-password values
         to the values provided. Returns the updated user profile.
 
+        **If you change the user's email address with this method, the user's access and refresh tokens
+          will no longer be valid. The /login API will need to be called with the new email address
+          to generate new access and refresh tokens.**
+
         **Passwords cannot be changed with this method and will be ignored if specified.
           The PATCH method must be used to change passwords.**
+
         **id, creation_time and last_update_time values cannot be changed and will be ignored if speficied.**
       tags:
         - User (requester, volunteer and administrator) profiles

--- a/documentation/bechamel-api.yaml
+++ b/documentation/bechamel-api.yaml
@@ -11,7 +11,7 @@ info:
 
 
     The API described here is a **PROPOSAL** and is **NOT YET IMPLEMENTED**.
-  version: 0.0.5
+  version: 0.0.6
 
 components:
   securitySchemes:
@@ -75,6 +75,11 @@ components:
           description: id for this user. Non-mutable, read-only value with no guaranteed semantics.
           readOnly: true
           example: 1234
+        email:
+          type: string
+          description: Email address for this user. This email address will be the address used to authenticate (login),
+            to communicate with the user, to send password reset requests to, and for other Lasagna Love purposes.
+          example: georgenewman@example.com
         roles:
           type: array
           description: |
@@ -112,21 +117,11 @@ components:
               - superadmin
               - service
           example: ["chef"]
-        username:
-          type: string
-          description: Username for the user. This is the value to supply to the authentication API
-            to authenticate the user.
-          example: UHFStationOwner
         password:
           type: string
           description: Placeholder for this user's password. Write-only for creating or updating users.
             A blank string is returned when retrieving a user profile instead of the user's password.
           example: ""
-        email:
-          type: string
-          description: Email address for this user. This email address will be the address used to communicate
-            with the user, to send password reset requests to, and for other Lasagna Love purposes.
-          example: georgenewman@example.com
         email_validated:
           type: boolean
           description: true if the user's email address was successfully validated by the Lasagna Love system,
@@ -188,6 +183,10 @@ components:
 
             Australia - this is the three letter abbreviation of the territory, e.g. NSA for New South Wales
           example: OK
+        country:
+          type: string
+          description: The ISO 3166 two letter country code for the country the user resides in.
+          example: US
         postal_code:
           type: string
           description: The postal code the user resides in.
@@ -252,15 +251,15 @@ components:
         volunteer_info:
           $ref: '#/components/schemas/volunteer_info'
       required:
-        - roles
-        - username
-        - password
         - email
+        - roles
+        - password
         - given_name
         - family_name
         - street_address
         - city
         - state_or_province
+        - country
         - postal_code
         - mobile_phone
 
@@ -596,7 +595,7 @@ paths:
               type: object
               oneOf:
                 - properties:
-                    username:
+                    email:
                       type: string
                     password:
                       type: string
@@ -606,7 +605,7 @@ paths:
       responses:
         # NOTE: the returned responses from this endpoint are intentionally not the shared API responses.
         '200':  # ok
-          description: Generated JWT token for the provided username and password
+          description: Generated JWT token for the provided email address and password
           content:
             application/json:
               schema:
@@ -923,10 +922,9 @@ paths:
             schema:
               $ref: '#/components/schemas/profile'
             example:
-              roles: ["chef"]
-              username: UHFStationOwner
-              password: PasswordForTheUser
               email: georgenewman@example.com
+              roles: ["chef"]
+              password: PasswordForTheUser
               email_validated: false
               given_name: George
               family_name: Newman
@@ -937,6 +935,7 @@ paths:
               city: Tulsa
               state_or_province: OK
               postal_code: "74127"
+              country: US
               home_phone: (02) 1234 5678
               mobile_phone: +1 312 555-1212
               mobile_contact_permission: true
@@ -1123,9 +1122,8 @@ paths:
               $ref: '#/components/schemas/profile'
             example:
               roles: ["recipient"]
-              username: UHFStationOwner
-              password: PasswordForTheUser
               email: georgenewman@example.com
+              password: PasswordForTheUser
               email_validated: false
               given_name: George
               family_name: Newman
@@ -1136,6 +1134,7 @@ paths:
               city: Tulsa
               state_or_province: OK
               postal_code: "74127"
+              country: US
               home_phone: (02) 1234 5678
               mobile_phone: +1 312 555-1212
               mobile_contact_permission: true

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/go-playground/validator/v10 v10.14.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/iancoleman/strcase v0.2.0
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/internal/bechamel_utils.go
+++ b/internal/bechamel_utils.go
@@ -1,5 +1,9 @@
 package internal
 
+import (
+	"time"
+)
+
 // Project Ricotta: Bechamel API
 //
 // Internal utility functions used in Bechamel API
@@ -11,4 +15,15 @@ func StringIsInArray(s []string, str string) bool {
 		}
 	}
 	return false
+}
+
+// NOTE: this is not an arbitrary formatting string, this is required format string
+// to get time created in ISO 8601 simplified extended format as returned
+// by JavaScript's toISOString() function.
+func TimeAsISO8601String(theTime time.Time) string {
+	return theTime.Format("2006-01-02T15:04:05.000Z0700")
+}
+
+func CurrentTimeAsISO8601String() string {
+	return TimeAsISO8601String(time.Now().UTC())
 }

--- a/internal/bechamel_utils.go
+++ b/internal/bechamel_utils.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"reflect"
+	"strings"
 	"time"
 )
 
@@ -13,6 +15,39 @@ func StringIsInArray(s []string, str string) bool {
 		if v == str {
 			return true
 		}
+	}
+	return false
+}
+
+/*
+	    Verify that a provided value is of a suitable type to be assigned to a field (assignee)
+		in a PATCH operation
+
+		We consider float64 to be assignable to int and vice-versa, as the Bechamel API interface
+		currently only has integer numeric values. These come in from the JSON as float64 types.
+*/
+func ValuesAreUpdateCompatible(assignee reflect.Value, value reflect.Value) bool {
+	if assignee.Type() == value.Type() {
+		return true
+	}
+	if strings.HasPrefix(assignee.Type().String(), "int") &&
+		strings.HasPrefix(value.Type().String(), "float") {
+		return true
+	}
+	if strings.HasPrefix(assignee.Type().String(), "float") &&
+		strings.HasPrefix(value.Type().String(), "int") {
+		return true
+	}
+	// If interface to array, verify types in there match those of the assignee
+	if strings.HasPrefix(assignee.Type().String(), "[]") &&
+		strings.HasPrefix(value.Type().String(), "[]interface") {
+		for i := 0; i < value.Len(); i++ {
+			var innerValue = value.Index(i)
+			if assignee.Type().String()[2:] != innerValue.Elem().Type().String() {
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/internal/internal_test_data.go
+++ b/internal/internal_test_data.go
@@ -14,12 +14,11 @@ import (
 var LasagnaLoveUsersDummyData = []model.LasagnaLoveUser{
 	{
 		ID:                      1,
+		Email:                   "testuser1@example.com",
 		Roles:                   []string{"chef"},
-		Username:                "TestUser1",
 		Password:                "EsX3b/B4fCYGb2+iAs4fAIXQtiq3EydUDi03ECVvTEE=", // "password1, hashed"
 		GivenName:               "Test",
 		FamilyName:              "UserOne",
-		Email:                   "testuser1@example.com",
 		EmailValidated:          true,
 		CreationTime:            "2023-04-11T07:11:04.332Z",
 		LastUpdateTime:          "2023-06-06T13:00:00.000Z",
@@ -49,12 +48,11 @@ var LasagnaLoveUsersDummyData = []model.LasagnaLoveUser{
 	},
 	{
 		ID:                      2,
+		Email:                   "testuser2@example.com",
 		Roles:                   []string{"requester", "recipient"},
-		Username:                "TestUser2",
 		Password:                "TnhbYUymFq5gr1jvyw1AmTviqlp3sYp7t0VxfT7ut1M=", // "password2", hashed
 		GivenName:               "Test",
 		FamilyName:              "UserTwo",
-		Email:                   "testuser2@example.com",
 		EmailValidated:          true,
 		CreationTime:            "2023-05-16T06:44:19.794Z",
 		LastUpdateTime:          "2023-06-06T13:00:00.000Z",

--- a/internal/jwt_utils.go
+++ b/internal/jwt_utils.go
@@ -14,30 +14,30 @@ import (
 	"github.com/golang-jwt/jwt"
 )
 
-func GenerateAccessJWT(userName string) (string, error) {
-	return GenerateAccessJWTWithTTL(userName, config.RuntimeConfig.AccessJWTTTL())
+func GenerateAccessJWT(emailAddress string) (string, error) {
+	return GenerateAccessJWTWithTTL(emailAddress, config.RuntimeConfig.AccessJWTTTL())
 }
 
-func GenerateAccessJWTWithTTL(userName string, ttl int) (string, error) {
+func GenerateAccessJWTWithTTL(emailAddress string, ttl int) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"userName": userName,
-		"nbf":      time.Now().Unix(),
-		"iat":      time.Now().Unix(),
-		"exp":      time.Now().Add(time.Second * time.Duration(ttl)).Unix(),
+		"email": emailAddress,
+		"nbf":   time.Now().Unix(),
+		"iat":   time.Now().Unix(),
+		"exp":   time.Now().Add(time.Second * time.Duration(ttl)).Unix(),
 	})
 	return token.SignedString(config.RuntimeConfig.AccessJWTSigningKey())
 }
 
-func GenerateRefreshJWT(userName string) (string, error) {
-	return GenerateAccessJWTWithTTL(userName, config.RuntimeConfig.RefreshJWTTTL())
+func GenerateRefreshJWT(emailAddress string) (string, error) {
+	return GenerateAccessJWTWithTTL(emailAddress, config.RuntimeConfig.RefreshJWTTTL())
 }
 
-func GenerateRefreshJWTWithTTL(userName string, ttl int) (string, error) {
+func GenerateRefreshJWTWithTTL(emailAddress string, ttl int) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"userName": userName,
-		"nbf":      time.Now().Unix(),
-		"iat":      time.Now().Unix(),
-		"exp":      time.Now().Add(time.Second * time.Duration(ttl)).Unix(),
+		"email": emailAddress,
+		"nbf":   time.Now().Unix(),
+		"iat":   time.Now().Unix(),
+		"exp":   time.Now().Add(time.Second * time.Duration(ttl)).Unix(),
 	})
 	return token.SignedString(config.RuntimeConfig.RefreshJWTSigningKey())
 }
@@ -61,7 +61,7 @@ func VerifyAccessJWT(jwtTokenString string) (string, error) {
 	if token.Valid {
 		if claims, ok := token.Claims.(jwt.MapClaims); ok {
 			if err = claims.Valid(); err == nil {
-				return fmt.Sprint(claims["userName"]), nil
+				return fmt.Sprint(claims["email"]), nil
 			} else {
 				return "", errors.New("supplied JWT expired or not yet valid")
 			}
@@ -102,7 +102,7 @@ func VerifyRefreshJWT(jwtTokenString string) (string, error) {
 	if token.Valid {
 		if claims, ok := token.Claims.(jwt.MapClaims); ok {
 			if err = claims.Valid(); err == nil {
-				return fmt.Sprint(claims["userName"]), nil
+				return fmt.Sprint(claims["email"]), nil
 			} else {
 				return "", errors.New("supplied JWT expired or not yet valid")
 			}
@@ -130,14 +130,14 @@ func GetUserFromAuthHeader(authHeader string) (model.LasagnaLoveUser, error) {
 	}
 
 	tokenString := authHeader[len("Bearer "):]
-	userName, err := VerifyAccessJWT(tokenString)
+	emailAddress, err := VerifyAccessJWT(tokenString)
 	if err != nil {
 		return model.LasagnaLoveUser{}, errors.New("provided authorization token could not be authorized")
 	}
 
-	userProfile, err := GetUserByUserName(userName)
+	userProfile, err := GetUserByEmailAddress(emailAddress)
 	if err != nil {
-		return model.LasagnaLoveUser{}, errors.New("profile not found for user with supplied userName")
+		return model.LasagnaLoveUser{}, errors.New("profile not found for user with supplied email address")
 	}
 
 	return userProfile, nil

--- a/internal/request_access.go
+++ b/internal/request_access.go
@@ -9,7 +9,6 @@ package internal
 import (
 	"errors"
 	"project-ricotta/bechamel-api/model"
-	"time"
 )
 
 func findRequest(requestFilter func(model.LasagnaLoveRequest) bool) (model.LasagnaLoveRequest, error) {
@@ -46,10 +45,7 @@ func AddNewRequest(newRequest model.LasagnaLoveRequest) (model.LasagnaLoveReques
 	if newRequest.Type == "" {
 		newRequest.Type = "meal"
 	}
-	// NOTE: this is not an arbitrary formatting string, this is required format string
-	// to get time created in ISO 8601 simplified extended format as returned
-	// by JavaScript's toISOString() function.
-	newRequest.CreationTime = time.Now().UTC().Format("2006-01-02T15:04:05.000Z0700")
+	newRequest.CreationTime = CurrentTimeAsISO8601String()
 	newRequest.LastUpdateTime = newRequest.CreationTime
 
 	LasagnaLoveRequests_DummyData = append(LasagnaLoveRequests_DummyData, newRequest)

--- a/internal/user_access.go
+++ b/internal/user_access.go
@@ -81,21 +81,29 @@ func AddNewUser(newUserProfile model.LasagnaLoveUser) (model.LasagnaLoveUser, er
 func UpdateUser(userID int, updates map[string]any) (model.LasagnaLoveUser, error) {
 	didMakeUpdates := false
 
-	currentUserProfile, err := GetUserByID(userID)
+	var currentUserProfile model.LasagnaLoveUser
+	_, err := GetUserByID(userID)
 	if err != nil {
 		return model.LasagnaLoveUser{}, errors.New("could not obtain user for supplied ID")
 	}
+
+	// The double loop here is intentional - this is to prevent partial updates
+	// by making sure all fields supplied are valid before making any updates
 	for key := range updates {
 		rfl := reflect.ValueOf(&currentUserProfile).Elem()
 		if fld := rfl.FieldByName(key); !fld.IsValid() {
 			return model.LasagnaLoveUser{}, errors.New("invalid field name supplied for update")
 		}
+		// TODO: unaccepted field handling
+		// TODO: nested types/type ptrs (e.g. attestations)
 	}
 
 	// TODO: adding and updating will likely need to be datastore dependent and not common.
 	// For the integrated fixed data, note the switch to directly accessing the LasagnaLoveUsersDummyData here.
 	// TODO: need to set the referenced data structures as well, otherwise they need to be filled in full?
 	for key, value := range updates {
+		// TODO: password handling
+		// TODO: nested types/type ptrs (e.g. attestations)
 		reflect.ValueOf(&LasagnaLoveUsersDummyData[userID-1]).Elem().FieldByName(key).Set(reflect.ValueOf(value))
 		didMakeUpdates = true
 	}

--- a/internal/user_access.go
+++ b/internal/user_access.go
@@ -9,7 +9,7 @@ package internal
 import (
 	"errors"
 	"project-ricotta/bechamel-api/model"
-	"time"
+	"reflect"
 )
 
 func findUser(userFilter func(model.LasagnaLoveUser) bool) (model.LasagnaLoveUser, error) {
@@ -21,13 +21,13 @@ func findUser(userFilter func(model.LasagnaLoveUser) bool) (model.LasagnaLoveUse
 	return model.LasagnaLoveUser{}, errors.New("no user found with the supplied criteria")
 }
 
-func AuthorizeUser(userName string, password string) (model.LasagnaLoveUser, error) {
-	if userName == "" || password == "" {
-		return model.LasagnaLoveUser{}, errors.New("userName and password must be non-empty")
+func AuthorizeUser(emailAddress string, password string) (model.LasagnaLoveUser, error) {
+	if emailAddress == "" || password == "" {
+		return model.LasagnaLoveUser{}, errors.New("email and password must be non-empty")
 	}
 
 	return findUser(func(u model.LasagnaLoveUser) bool {
-		return u.Username == userName && u.Password == HashPassword(password)
+		return u.Email == emailAddress && u.Password == HashPassword(password)
 	})
 }
 
@@ -35,17 +35,9 @@ func GetUserByID(userID int) (model.LasagnaLoveUser, error) {
 	return findUser(func(u model.LasagnaLoveUser) bool { return u.ID == userID })
 }
 
-func GetUserByUserName(userName string) (model.LasagnaLoveUser, error) {
-	if userName == "" {
-		return model.LasagnaLoveUser{}, errors.New("userName must be non-empty")
-	}
-
-	return findUser(func(u model.LasagnaLoveUser) bool { return u.Username == userName })
-}
-
 func GetUserByEmailAddress(emailAddress string) (model.LasagnaLoveUser, error) {
 	if emailAddress == "" {
-		return model.LasagnaLoveUser{}, errors.New("emailAddress must be non-empty")
+		return model.LasagnaLoveUser{}, errors.New("email must be non-empty")
 	}
 
 	return findUser(func(u model.LasagnaLoveUser) bool { return u.Email == emailAddress })
@@ -54,10 +46,9 @@ func GetUserByEmailAddress(emailAddress string) (model.LasagnaLoveUser, error) {
 func AddNewUser(newUserProfile model.LasagnaLoveUser) (model.LasagnaLoveUser, error) {
 	// Not allowed to specify an userID - error if one is provided
 	if newUserProfile.ID != 0 {
-		return model.LasagnaLoveUser{}, errors.New("userID may not be specified")
+		return model.LasagnaLoveUser{}, errors.New("profile ID may not be specified")
 	}
 	if len(newUserProfile.Roles) == 0 ||
-		newUserProfile.Username == "" ||
 		newUserProfile.Password == "" ||
 		newUserProfile.Email == "" ||
 		newUserProfile.GivenName == "" ||
@@ -65,6 +56,7 @@ func AddNewUser(newUserProfile model.LasagnaLoveUser) (model.LasagnaLoveUser, er
 		len(newUserProfile.StreetAddress) == 0 ||
 		newUserProfile.City == "" ||
 		newUserProfile.StateOrProvince == "" ||
+		newUserProfile.Country == "" ||
 		newUserProfile.PostalCode == "" ||
 		newUserProfile.MobilePhone == "" {
 		return model.LasagnaLoveUser{}, errors.New("invalid or incomplete user data")
@@ -74,20 +66,42 @@ func AddNewUser(newUserProfile model.LasagnaLoveUser) (model.LasagnaLoveUser, er
 			return model.LasagnaLoveUser{}, errors.New("invalid value supplied in roles array")
 		}
 	}
-	if _, err := GetUserByUserName(newUserProfile.Username); err == nil {
-		return model.LasagnaLoveUser{}, errors.New("username already exists")
-	}
 	if _, err := GetUserByEmailAddress(newUserProfile.Email); err == nil {
 		return model.LasagnaLoveUser{}, errors.New("email address already in use, dupliate usage not permitted")
 	}
 
 	newUserProfile.ID = len(LasagnaLoveUsersDummyData) + 1
 	newUserProfile.Password = HashPassword(newUserProfile.Password)
-	// NOTE: this is not an arbitrary formatting string, this is required format string
-	// to get time created in ISO 8601 simplified extended format as returned
-	// by JavaScript's toISOString() function.
-	newUserProfile.CreationTime = time.Now().UTC().Format("2006-01-02T15:04:05.000Z0700")
+	newUserProfile.CreationTime = CurrentTimeAsISO8601String()
 	newUserProfile.LastUpdateTime = newUserProfile.CreationTime
 	LasagnaLoveUsersDummyData = append(LasagnaLoveUsersDummyData, newUserProfile)
 	return newUserProfile, nil
+}
+
+func UpdateUser(userID int, updates map[string]any) (model.LasagnaLoveUser, error) {
+	didMakeUpdates := false
+
+	currentUserProfile, err := GetUserByID(userID)
+	if err != nil {
+		return model.LasagnaLoveUser{}, errors.New("could not obtain user for supplied ID")
+	}
+	for key := range updates {
+		rfl := reflect.ValueOf(&currentUserProfile).Elem()
+		if fld := rfl.FieldByName(key); !fld.IsValid() {
+			return model.LasagnaLoveUser{}, errors.New("invalid field name supplied for update")
+		}
+	}
+
+	// TODO: adding and updating will likely need to be datastore dependent and not common.
+	// For the integrated fixed data, note the switch to directly accessing the LasagnaLoveUsersDummyData here.
+	// TODO: need to set the referenced data structures as well, otherwise they need to be filled in full?
+	for key, value := range updates {
+		reflect.ValueOf(&LasagnaLoveUsersDummyData[userID-1]).Elem().FieldByName(key).Set(reflect.ValueOf(value))
+		didMakeUpdates = true
+	}
+	if didMakeUpdates {
+		LasagnaLoveUsersDummyData[userID-1].LastUpdateTime = CurrentTimeAsISO8601String()
+	}
+
+	return LasagnaLoveUsersDummyData[userID-1], nil
 }

--- a/internal/user_access_test.go
+++ b/internal/user_access_test.go
@@ -26,7 +26,7 @@ func TestAuthorizeUser(t *testing.T) {
 	tests := []userTestType{
 		{
 			name:    "Correct credentials",
-			call:    func() (model.LasagnaLoveUser, error) { return AuthorizeUser("TestUser1", "password1") },
+			call:    func() (model.LasagnaLoveUser, error) { return AuthorizeUser("testuser1@example.com", "password1") },
 			wantErr: false,
 		},
 		{
@@ -54,29 +54,12 @@ func TestGetUserByID(t *testing.T) {
 	runUserTests(t, tests)
 }
 
-func TestGetUserByUserName(t *testing.T) {
-	tests := []userTestType{
-		{
-			name:    "Existing username",
-			call:    func() (model.LasagnaLoveUser, error) { return GetUserByUserName("TestUser1") },
-			wantErr: false,
-		},
-		{
-			name:    "Non-existing username",
-			call:    func() (model.LasagnaLoveUser, error) { return GetUserByUserName("NonExistingUser") },
-			wantErr: true,
-		},
-	}
-	runUserTests(t, tests)
-}
-
 func TestAddNewUser(t *testing.T) {
 	tests := []userTestType{
 		{
 			name: "Add new user with insufficient data",
 			call: func() (model.LasagnaLoveUser, error) {
 				return AddNewUser(model.LasagnaLoveUser{
-					Username:   "TestUser3",
 					Password:   "password3",
 					GivenName:  "Test",
 					FamilyName: "UserThree",
@@ -89,9 +72,8 @@ func TestAddNewUser(t *testing.T) {
 			call: func() (model.LasagnaLoveUser, error) {
 				return AddNewUser(model.LasagnaLoveUser{
 					Roles:           []string{"chef", "invalid"},
-					Username:        "TestUser-invalid role",
-					Password:        "password3",
 					Email:           "testuser3@example.com",
+					Password:        "password3",
 					GivenName:       "Test",
 					FamilyName:      "UserThree",
 					StreetAddress:   []string{"111 Testing Plaza", "Suite 1"},
@@ -103,30 +85,18 @@ func TestAddNewUser(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Add user with duplicated Username",
-			call: func() (model.LasagnaLoveUser, error) {
-				return AddNewUser(model.LasagnaLoveUser{
-					Username:   "TestUser1",
-					Password:   "password1",
-					GivenName:  "Test",
-					FamilyName: "UserOne",
-				})
-			},
-			wantErr: true,
-		},
-		{
 			name: "Add new user",
 			call: func() (model.LasagnaLoveUser, error) {
 				return AddNewUser(model.LasagnaLoveUser{
 					Roles:           []string{"chef"},
-					Username:        "TestUser3",
-					Password:        "password3",
 					Email:           "testuser3@example.com",
+					Password:        "password3",
 					GivenName:       "Test",
 					FamilyName:      "UserThree",
 					StreetAddress:   []string{"111 Testing Plaza", "Suite 1"},
 					City:            "Anywhere",
 					StateOrProvince: "AB",
+					Country:         "US",
 					PostalCode:      "T5B 6W2",
 					MobilePhone:     "780-555-1212",
 				})
@@ -138,9 +108,8 @@ func TestAddNewUser(t *testing.T) {
 			call: func() (model.LasagnaLoveUser, error) {
 				return AddNewUser(model.LasagnaLoveUser{
 					Roles:           []string{"chef"},
-					Username:        "newtestuser3",
-					Password:        "password3",
 					Email:           "testuser3@example.com",
+					Password:        "password3",
 					GivenName:       "Test",
 					FamilyName:      "UserThree",
 					StreetAddress:   []string{"111 Testing Plaza", "Suite 1"},

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"project-ricotta/bechamel-api/config"
 
@@ -29,7 +28,5 @@ func main() {
 	router.GET("/request/:requestID", getRequestByID)
 	router.POST("/request", postRequest)
 
-	if err := router.Run("0.0.0.0:8080"); err != nil {
-		log.Fatal(fmt.Errorf("could not start Gin server: %w", err))
-	}
+	log.Fatal(router.Run("0.0.0.0:8080"))
 }

--- a/main.go
+++ b/main.go
@@ -19,14 +19,29 @@ func main() {
 	corsConfig.AllowAllOrigins = true
 	corsConfig.AllowHeaders = append(corsConfig.AllowHeaders, "authorization")
 	router.Use(cors.New(corsConfig))
-	router.POST("/login", postUserAuthorization)
-	router.GET("/profile", getCurrentUserProfile)
-	router.PATCH("/profile", patchCurrentUserProfile)
-	router.POST("/profile", postUserProfile)
-	router.GET("/profile/:userID", getUserProfileByID)
-	router.PATCH("/profile/:userID", patchUserProfileByID)
-	router.GET("/request/:requestID", getRequestByID)
-	router.POST("/request", postRequest)
+
+	dev := router.Group("/dev")
+	{
+		dev.POST("/login", postUserAuthorization)
+		dev.GET("/profile", getCurrentUserProfile)
+		dev.PATCH("/profile", patchCurrentUserProfile)
+		dev.POST("/profile", postUserProfile)
+		dev.GET("/profile/:userID", getUserProfileByID)
+		dev.PATCH("/profile/:userID", patchUserProfileByID)
+		dev.GET("/request/:requestID", getRequestByID)
+		dev.POST("/request", postRequest)
+	}
+	v0 := router.Group("/v0")
+	{
+		v0.POST("/login", postUserAuthorization)
+		v0.GET("/profile", getCurrentUserProfile)
+		v0.PATCH("/profile", patchCurrentUserProfile)
+		v0.POST("/profile", postUserProfile)
+		v0.GET("/profile/:userID", getUserProfileByID)
+		v0.PATCH("/profile/:userID", patchUserProfileByID)
+		v0.GET("/request/:requestID", getRequestByID)
+		v0.POST("/request", postRequest)
+	}
 
 	log.Fatal(router.Run("0.0.0.0:8080"))
 }

--- a/main.go
+++ b/main.go
@@ -22,8 +22,10 @@ func main() {
 	router.Use(cors.New(corsConfig))
 	router.POST("/login", postUserAuthorization)
 	router.GET("/profile", getCurrentUserProfile)
-	router.GET("/profile/:userID", getUserProfileByID)
+	router.PATCH("/profile", patchCurrentUserProfile)
 	router.POST("/profile", postUserProfile)
+	router.GET("/profile/:userID", getUserProfileByID)
+	router.PATCH("/profile/:userID", patchUserProfileByID)
 	router.GET("/request/:requestID", getRequestByID)
 	router.POST("/request", postRequest)
 

--- a/model/LasagnaLoveAuthRequest.go
+++ b/model/LasagnaLoveAuthRequest.go
@@ -10,7 +10,7 @@ package model
 // with the same gin Context, which seems to prevent checking
 // against two JSON schemas in succession
 type LasagnaLoveAuthRequest struct {
-	Username     string `json:"username"`
+	Email        string `json:"email"`
 	Password     string `json:"password"`
 	RefreshToken string `json:"refresh_token"`
 }

--- a/model/LasagnaLoveUser.go
+++ b/model/LasagnaLoveUser.go
@@ -4,19 +4,19 @@ import "encoding/json"
 
 type LasagnaLoveUser struct {
 	ID                      int                       `json:"id"`
+	Email                   string                    `json:"email"`
 	Roles                   []string                  `json:"roles"`
-	Username                string                    `json:"username"`
 	Password                string                    `json:"password"`
 	GivenName               string                    `json:"given_name"`
 	MiddleOrMaidenName      string                    `json:"middle_or_maiden_name,omitempty"`
 	FamilyName              string                    `json:"family_name"`
-	Email                   string                    `json:"email"`
 	EmailValidated          bool                      `json:"email_validated"`
 	CreationTime            string                    `json:"creation_time"`
 	LastUpdateTime          string                    `json:"last_update_time"`
 	StreetAddress           []string                  `json:"street_address"`
 	City                    string                    `json:"city"`
 	StateOrProvince         string                    `json:"state_or_province"`
+	Country                 string                    `json:"country"`
 	PostalCode              string                    `json:"postal_code"`
 	HomePhone               string                    `json:"home_phone,omitempty"`
 	MobilePhone             string                    `json:"mobile_phone"`

--- a/model/PatchUpdateStruct.go
+++ b/model/PatchUpdateStruct.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/iancoleman/strcase"
+)
+
+type PatchUpdateStruct map[string]interface{}
+
+func (inStruct PatchUpdateStruct) PascalCase() PatchUpdateStruct {
+	retStruct := make(PatchUpdateStruct)
+	for k, v := range inStruct {
+		switch vt := v.(type) {
+		case map[string]interface{}:
+			retStruct[strcase.ToCamel(k)] = (PatchUpdateStruct)(vt).PascalCase()
+		default:
+			retStruct[strcase.ToCamel(k)] = vt
+		}
+	}
+	return retStruct
+}


### PR DESCRIPTION
**Breaking API changes**
- Removes the use of 'username' and changes the /login API endpoint to use email & password. Places in code where user profiles were obtained by username have been changed to use email instead.
- Adds a required 'country' field to the Profile to store the user's address's country. While we could derive this from the postal_code, this seems a useful optimization to have.
- Adds versioning to the API, with prefixes /v0 and /dev. /v0 will become /v1 when the initial "Project Ricotta production release" is made. /dev is used to refer to the API as it is in active development and should not be used for production.

**Non-breaking API changes**
- Adds initial implementation of PATCH for /profile and /profile/:id. Implementations lack elegance in spots but they do:
  - Check for invalid field key names coming in
  - Check for invalid value types coming in
  - Create a RecipientInfo and VolunteerInfo if needed and fill appropriately
  - Hash password correctly if it is supplied

Updates API version in documentation to 0.0.6

_Reviewers_ you may use "testuser1@example.com / password1" or "testuser2@example.com / password2" to login. Previously generated JWTs will no longer function.